### PR TITLE
修复在iOS12.2 图片加载不出来的问题

### DIFF
--- a/PureCamera/PureCamera.m
+++ b/PureCamera/PureCamera.m
@@ -35,7 +35,7 @@
     [super viewDidLoad];
     //拍照按钮
     [self InitializeCamera];
-    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle bundleForClass:[self class]] pathForResource:@"PureCamera" ofType:@"bundle"]];
     self.snapButton = [UIButton buttonWithType:UIButtonTypeCustom];
     self.snapButton.clipsToBounds = YES;
     self.snapButton.layer.cornerRadius =75 / 2.0f;


### PR DESCRIPTION
pod 引入
在真机上测试，发现多次图片无法正常加载的问题，调试后发现获取到的路径不正确，所以UIImage为空造成图片不能展示